### PR TITLE
[WIP][gu-hardware] Add support for detection of the number of cores.

### DIFF
--- a/gu-hardware/Cargo.toml
+++ b/gu-hardware/Cargo.toml
@@ -19,6 +19,7 @@ serde_json = "1.0"
 serde_derive = "1.0"
 actix-web = "0.7"
 hostname = "^0.1"
+num_cpus = "1.0"
 
 [dependencies.cl-sys]
 version="0.4"

--- a/gu-hardware/src/actor.rs
+++ b/gu-hardware/src/actor.rs
@@ -47,6 +47,7 @@ pub struct Hardware {
     os: Option<OsType>,
     #[serde(skip_serializing_if = "Option::is_none")]
     hostname: Option<String>,
+    num_cores: usize,
 }
 
 impl Message for HardwareQuery {
@@ -118,6 +119,7 @@ impl Handler<HardwareQuery> for HardwareActor {
                         disk,
                         os: os_type(),
                         hostname,
+                        num_cores: num_cpus::get_physical()
                     })
                 }).into_actor(self),
         )

--- a/gu-hardware/src/lib.rs
+++ b/gu-hardware/src/lib.rs
@@ -15,6 +15,7 @@ extern crate actix_web;
 extern crate clap;
 extern crate futures;
 extern crate hostname;
+extern crate num_cpus;
 extern crate serde;
 extern crate serde_json;
 extern crate sysinfo;

--- a/gu-hub/webapp/providers.html
+++ b/gu-hub/webapp/providers.html
@@ -19,6 +19,7 @@
                     <th>Node Name</th>
                     <th>RAM</th>
                     <th>GPU</th>
+                    <th>Number of cores</th>
                     <th>Sessions</th>
                     <th>Connection</th>
                 </tr>
@@ -29,6 +30,7 @@
                         <td gu-peer-name></td>
                         <td gu-peer-ram></td>
                         <td gu-peer-gpu></td>
+                        <td gu-peer-num_cores>{{peer.num_cores}}</td>
                         <td>{{(peer.sessions.length || 0)}}</td>
                         <td>{{peer.peerAddr}}</td>
                     </tr>

--- a/gu-hub/webapp/services/sessionMan.js
+++ b/gu-hub/webapp/services/sessionMan.js
@@ -114,6 +114,7 @@ angular.module('gu').service('sessionMan', function ($http, $log, $q, hubApi, hd
                 peer.os = ok.os || peer.os;
                 osMap[peer.nodeId] = ok.os || peer.os || 'unk';
                 peer.hostname = ok.hostname;
+                peer.num_cores = ok.num_cores;
             }
         })
         ;


### PR DESCRIPTION
Closes #73.

Why does the webapp fail to pick up the `peer.num_cores`?