### PR TITLE
Revert "Rename the deprecated lint clippy to clippy::all"

### DIFF
--- a/gu-net/src/proto/wire.rs
+++ b/gu-net/src/proto/wire.rs
@@ -5,7 +5,7 @@
 #![allow(non_camel_case_types)]
 #![allow(unused_imports)]
 #![allow(unknown_lints)]
-#![allow(clippy::all)]
+#![allow(clippy)]
 #![cfg_attr(rustfmt, rustfmt_skip)]
 
 


### PR DESCRIPTION
Reverts failing golemfactory/golem-unlimited#96