### PR TITLE
Add the process output to the error type in for Command::Exec

### DIFF
--- a/gu-provider/src/sync_exec.rs
+++ b/gu-provider/src/sync_exec.rs
@@ -111,7 +111,7 @@ error_chain!(
     errors {
         MailboxError(e : MailboxError){}
         ExecutionError(exec: String, args: Vec<String>, output: process::Output) {
-            display("failed to execute command: {}, {:?}", exec, args)
+             display("failed to execute command: {}, {:?}, {:?}", exec, args, output)
         }
     }
 );

--- a/gu-provider/src/sync_exec.rs
+++ b/gu-provider/src/sync_exec.rs
@@ -88,7 +88,7 @@ impl Handler<Exec> for SyncExec {
                             );
                             Ok(ExecResult::Run(output))
                         } else {
-                            Err(ErrorKind::ExecutionError(executable, args).into())
+                            Err(ErrorKind::ExecutionError(executable, args, output).into())
                         }
                     }
                     Err(e) => Err(e.into()),
@@ -110,7 +110,7 @@ error_chain!(
 
     errors {
         MailboxError(e : MailboxError){}
-        ExecutionError(exec: String, args: Vec<String>) {
+        ExecutionError(exec: String, args: Vec<String>, output: process::Output) {
             display("failed to execute command: {}, {:?}", exec, args)
         }
     }

--- a/gu-provider/src/sync_exec.rs
+++ b/gu-provider/src/sync_exec.rs
@@ -122,7 +122,6 @@ impl From<MailboxError> for Error {
     }
 }
 
-/*
 #[cfg(test)]
 mod test {
     use super::{Exec, ExecResult, SyncExecManager};
@@ -131,7 +130,7 @@ mod test {
     use gu_actix::flatten::FlattenFuture;
 
     #[test]
-    fn test_sync_exec_date() {
+    fn test_sync_exec_echo() {
         System::run(|| {
             Arbiter::spawn(
                 SyncExecManager::from_registry()
@@ -153,13 +152,4 @@ mod test {
             )
         });
     }
-
-    //    #[test]
-    //    fn test_map_and_map_err() {
-    //        let mut v = Vec::new();
-    //        Ok("foo".to_string())
-    //            .map(|i| {v.push(i); v})
-    //            .map_err(|e : String| {v.push(e); v});
-    //    }
 }
-*/


### PR DESCRIPTION
Currently it just says "The command failed", which tells nothing.