### PR TITLE
Add CreateOptions definition to OpenAPI yaml

### DIFF
--- a/gu-hub-api.yaml
+++ b/gu-hub-api.yaml
@@ -575,6 +575,29 @@ definitions:
         uniqueItems: true
         items:
           type: string
+      options:
+        $ref: '#/definitions/CreateOptions'
+  CreateOptions:
+    type: object
+    properties:
+      volumes:
+        type: array
+        items:
+          $ref: '#/definitions/VolumeDef'
+      cmd:
+        type: array
+        items:
+          type: string
+  VolumeDef:
+    type: object
+    properties:
+      BindRw:
+        type: object
+        properties:
+          src: 
+            type: string 
+          target: 
+            type: string
   Command:
     type: object
     properties:

--- a/gu-hub-api.yaml
+++ b/gu-hub-api.yaml
@@ -577,7 +577,13 @@ definitions:
           type: string
       options:
         $ref: '#/definitions/CreateOptions'
+
   CreateOptions:
+    anyOf:
+    - type: null
+    - $ref: '#/definitions/DockerCreateOptions'
+
+  DockerCreateOptions:
     type: object
     properties:
       volumes:
@@ -603,6 +609,10 @@ definitions:
     properties:
       exec:
         $ref: '#/definitions/ExecCommand'
+      open:
+        type: null
+      close:
+        type: null
       start:
         $ref: '#/definitions/StartCommand'
       stop:


### PR DESCRIPTION
Allows creating `docker` deployments from autogenerated code as follows:

```python
import gu_rest_api
from gu_rest_api import SessionApi, PeerApi
from pprint import pprint

session_id = 0  # some session id 
node_id= '0x3ec76579b211c857b166d51d65ae8347918e6994'  # some node id
deployment_id='hd::52769178-7301-4dcf-bd95-b9b68299d05c'  # some deployment id

configuration = gu_rest_api.Configuration()
client = gu_rest_api.ApiClient(configuration)
peer_api_instance = gu_rest_api.PeerApi(client)

deployment_spec = gu_rest_api.DeploymentSpec(
    env_type='docker',
    image=gu_rest_api.DeploymentSpecImage(
        'SHA256:7c23c976eb6926beb91ad04a5038427c2e8c05825bb9db73c40266f86f61dfd0',
        'golemfactory/glambda:1.3'),
    name='my_sweet_deployment',
    tags=[],
    options=gu_rest_api.CreateOptions(
        volumes=[gu_rest_api.VolumeDef(bind_rw={'src': 'resources', 'target': '/golem/resources'})]
    )
)

deployment = peer_api_instance.create_deployment(node_id, 
                                            deployment_spec)
deployments = peer_api_instance.list_deployments(node_id)
pprint(deployments)
```