### PR TITLE
Add a conversion Peer -> ProviderRef

### DIFF
--- a/gu-client/src/async.rs
+++ b/gu-client/src/async.rs
@@ -20,6 +20,7 @@ use serde_derive::*;
 use std::borrow::Borrow;
 use std::collections::VecDeque;
 use std::marker::PhantomData;
+use std::ops::Deref;
 use std::sync::Arc;
 use std::time::Duration;
 use std::{env, str};
@@ -505,6 +506,15 @@ impl Peer {
             self.hub_session.hub_connection.hub_connection_inner.url, self.node_id
         );
         self.hub_session.hub_connection.fetch_json(&url)
+    }
+}
+
+impl From<Peer> for ProviderRef {
+    fn from(peer: Peer) -> Self {
+        Self {
+            connection: peer.hub_session.hub_connection,
+            node_id: peer.node_id
+        }
     }
 }
 

--- a/gu-model/src/envman.rs
+++ b/gu-model/src/envman.rs
@@ -93,7 +93,7 @@ impl PublicMessage for SessionUpdate {
     const ID: u32 = 38;
 }
 
-#[derive(Serialize, Deserialize, Debug, Eq, Ord, PartialOrd, PartialEq, Hash)]
+#[derive(Copy, Clone, Serialize, Deserialize, Debug, Eq, Ord, PartialOrd, PartialEq, Hash)]
 #[serde(rename_all = "camelCase")]
 pub enum ResourceFormat {
     Raw,
@@ -106,7 +106,7 @@ impl Default for ResourceFormat {
     }
 }
 
-#[derive(Serialize, Deserialize, Hash, Eq, PartialEq, Debug)]
+#[derive(Clone, Serialize, Deserialize, Hash, Eq, PartialEq, Debug)]
 #[serde(rename_all = "camelCase")]
 pub enum Command {
     Exec {


### PR DESCRIPTION
It would be useful to be able to call `rpc_call` on `Peer`, having a from conversion is a first approximation.