### PR TITLE
Add a regression test for #201

### DIFF
--- a/gu-client/src/integration_tests.rs
+++ b/gu-client/src/integration_tests.rs
@@ -1,5 +1,6 @@
 use actix::prelude::*;
 use futures::prelude::*;
+use futures::future;
 
 use crate::r#async::*;
 use gu_model::session::HubSessionSpec;
@@ -41,4 +42,22 @@ fn test_list_peers() {
 
     eprintln!("peers={:?}", peers);
 //    assert_eq!(peers.len(), session_peers.len());
+}
+
+/// Test if two ways of getting PeerInfo are consistent
+#[test]
+fn test_peer_info() {
+    let mut sys = System::new("test");
+    let connection = HubConnection::default();
+    let fut = connection
+        .list_peers()
+        .and_then(move |mut peers| {
+            let peerinfo = peers.next().unwrap();
+            let node_id = peerinfo.node_id;
+            let peerinfo2 = connection.peer(node_id).info();
+            future::ok(peerinfo).join(peerinfo2)
+        });
+
+    let (pi, pi2) = sys.block_on(fut).unwrap();
+    assert_eq!(pi.node_id, pi2.node_id);
 }


### PR DESCRIPTION
If `ProviderRef` implemented `Debug` and `PeerInfo` implemented `PartialEq`, I could just write
```
    assert_eq!(pi, pi2);
```