### PR TITLE
Reexport gu_net::NodeId in the client API

### DIFF
--- a/gu-client/src/async.rs
+++ b/gu-client/src/async.rs
@@ -3,7 +3,6 @@ use actix_web::{client, http, HttpMessage};
 use bytes::Bytes;
 use futures::{future, prelude::*};
 use gu_actix::release::{AsyncRelease, Handle};
-use gu_model::peers::PeerInfo;
 use gu_model::{
     deployment::DeploymentInfo,
     envman,
@@ -11,7 +10,6 @@ use gu_model::{
     HubInfo,
 };
 use gu_net::rpc::peer::PeerSessionInfo;
-use gu_net::types::NodeId;
 use gu_net::types::TryIntoNodeId;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
@@ -23,6 +21,7 @@ use std::{env, str};
 use url::Url;
 
 pub type HubSessionRef = Handle<HubSession>;
+pub use gu_net::NodeId;
 
 /// Connection to a single hub.
 #[derive(Clone, Debug)]


### PR DESCRIPTION
gumpi currently has `gu_net` as a dependency just to import `NodeId`.
I'm wondering whether we should reexport the whole `gu_model` from `gu_client`, in the following way: