### PR TITLE
Revert "Revert "Rename the deprecated lint clippy to clippy::all""

### DIFF
--- a/gu-net/src/proto/wire.rs
+++ b/gu-net/src/proto/wire.rs
@@ -5,7 +5,7 @@
 #![allow(non_camel_case_types)]
 #![allow(unused_imports)]
 #![allow(unknown_lints)]
-#![allow(clippy)]
+#![allow(clippy::all)]
 #![cfg_attr(rustfmt, rustfmt_skip)]
 
 


### PR DESCRIPTION
This reverts commit b0156f83851f4c1e1a6282a4e48114d9be309a00.
It was reverted because Rust stable didn't support scoped lints at that
time but this should no longer be the case.