### PR TITLE
Support ExecOptions in dockerman. 

### DIFF
--- a/gu-client/Cargo.toml
+++ b/gu-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gu-client"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["golemfactory"]
 edition = "2018"
 

--- a/gu-client/examples/gu-client.rs
+++ b/gu-client/examples/gu-client.rs
@@ -581,6 +581,7 @@ fn run_worker<S: Stream<Item = (Blob, BlenderTaskSpec), Error = Error>>(
                         Command::Exec {
                             executable: "./gu-render".into(),
                             args: Vec::new(),
+                            options: Default::default(),
                         },
                         Command::UploadFile {
                             uri: blob.uri(),

--- a/gu-client/examples/gu-client.rs
+++ b/gu-client/examples/gu-client.rs
@@ -581,7 +581,7 @@ fn run_worker<S: Stream<Item = (Blob, BlenderTaskSpec), Error = Error>>(
                         Command::Exec {
                             executable: "./gu-render".into(),
                             args: Vec::new(),
-                            working_dir: None
+                            working_dir: None,
                         },
                         Command::UploadFile {
                             uri: blob.uri(),

--- a/gu-client/examples/gu-client.rs
+++ b/gu-client/examples/gu-client.rs
@@ -581,7 +581,7 @@ fn run_worker<S: Stream<Item = (Blob, BlenderTaskSpec), Error = Error>>(
                         Command::Exec {
                             executable: "./gu-render".into(),
                             args: Vec::new(),
-                            options: Default::default(),
+                            working_dir: None
                         },
                         Command::UploadFile {
                             uri: blob.uri(),

--- a/gu-client/examples/hub_session.rs
+++ b/gu-client/examples/hub_session.rs
@@ -102,7 +102,7 @@ fn main() {
                         envman::Command::Exec {
                             executable: "gu-factor".to_string(),
                             args: vec!["100".to_string()],
-                            options: Default::default(),
+                            working_dir: None
                         },
                         envman::Command::AddTags(vec!["my_tag_2".to_string()]),
                     ]))

--- a/gu-client/examples/hub_session.rs
+++ b/gu-client/examples/hub_session.rs
@@ -102,6 +102,7 @@ fn main() {
                         envman::Command::Exec {
                             executable: "gu-factor".to_string(),
                             args: vec!["100".to_string()],
+                            options: Default::default(),
                         },
                         envman::Command::AddTags(vec!["my_tag_2".to_string()]),
                     ]))

--- a/gu-client/examples/hub_session.rs
+++ b/gu-client/examples/hub_session.rs
@@ -102,7 +102,7 @@ fn main() {
                         envman::Command::Exec {
                             executable: "gu-factor".to_string(),
                             args: vec!["100".to_string()],
-                            working_dir: None
+                            working_dir: None,
                         },
                         envman::Command::AddTags(vec!["my_tag_2".to_string()]),
                     ]))

--- a/gu-model/src/envman.rs
+++ b/gu-model/src/envman.rs
@@ -108,6 +108,12 @@ impl Default for ResourceFormat {
     }
 }
 
+#[derive(Clone, Serialize, Deserialize, Default, Hash, Eq, PartialEq, Debug)]
+pub struct ExecOptions {
+    pub user: Option<String>,
+    pub working_dir: Option<String>,
+}
+
 #[derive(Clone, Serialize, Deserialize, Hash, Eq, PartialEq, Debug)]
 #[serde(rename_all = "camelCase")]
 pub enum Command {
@@ -115,6 +121,7 @@ pub enum Command {
         // return cmd output
         executable: String,
         args: Vec<String>,
+        options: ExecOptions,
     },
     Open,
     Close,

--- a/gu-model/src/envman.rs
+++ b/gu-model/src/envman.rs
@@ -122,6 +122,7 @@ pub enum Command {
         // return cmd output
         executable: String,
         args: Vec<String>,
+        #[serde(default)]
         options: ExecOptions,
     },
     Open,

--- a/gu-model/src/envman.rs
+++ b/gu-model/src/envman.rs
@@ -109,8 +109,9 @@ impl Default for ResourceFormat {
 }
 
 #[derive(Clone, Serialize, Deserialize, Default, Hash, Eq, PartialEq, Debug)]
+#[serde(rename_all = "camelCase")]
 pub struct ExecOptions {
-    pub user: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub working_dir: Option<String>,
 }
 
@@ -240,6 +241,7 @@ mod test {
         if let Command::Exec {
             ref executable,
             ref args,
+            ..
         } = u.commands[0]
         {
             assert_eq!(executable, "gu-mine");

--- a/gu-provider/src/dockerman.rs
+++ b/gu-provider/src/dockerman.rs
@@ -91,9 +91,6 @@ impl DockerSession {
                 .with_attach_stdout(true)
                 .with_attach_stderr(true)
                 .with_cmd(args);
-            if let Some(user) = options.user {
-                config.set_user(user)
-            }
             if let Some(working_dir) = options.working_dir {
                 config.set_working_dir(working_dir)
             }

--- a/gu-provider/src/hdman.rs
+++ b/gu-provider/src/hdman.rs
@@ -11,7 +11,7 @@ use std::{
 
 use actix::{fut, prelude::*};
 use futures::{future, prelude::*};
-use log::{debug, error, info};
+use log::{debug, error, info, warn};
 use serde::{Deserialize, Serialize};
 
 use gu_actix::prelude::*;
@@ -295,7 +295,14 @@ fn run_command(
     match command {
         Command::Open => Box::new(fut::ok("Open mock".to_string())),
         Command::Close => Box::new(fut::ok("Close mock".to_string())),
-        Command::Exec { executable, args } => {
+        Command::Exec {
+            executable,
+            args,
+            options,
+        } => {
+            if options != Default::default() {
+                warn!("ExecOptions unimplemented in hdman");
+            }
             let executable = session.get_session_exec_path(&executable);
             let session_id = session_id.clone();
             let session_dir = session.workspace.path().to_owned();

--- a/gu-provider/src/hdman.rs
+++ b/gu-provider/src/hdman.rs
@@ -300,12 +300,10 @@ fn run_command(
             args,
             working_dir,
         } => {
-            if working_dir != None {
-                warn!("working_dir unimplemented in hdman");
-            }
             let executable = session.get_session_exec_path(&executable);
             let session_id = session_id.clone();
             let session_dir = session.workspace.path().to_owned();
+            let cwd = session_dir.join(working_dir.unwrap_or_default());
 
             info!("executing sync: {} {:?}", executable, args);
             Box::new(
@@ -314,7 +312,7 @@ fn run_command(
                         .send(Exec::Run {
                             executable,
                             args,
-                            cwd: session_dir.clone(),
+                            cwd,
                         })
                         .flatten_fut()
                         .map_err(move |e| e.to_string()),

--- a/gu-provider/src/hdman.rs
+++ b/gu-provider/src/hdman.rs
@@ -286,7 +286,7 @@ fn run_command(
     hd_man: &mut HdMan,
     session_id: String,
     command: Command,
-) -> Box<ActorFuture<Actor = HdMan, Item = String, Error = String>> {
+) -> Box<dyn ActorFuture<Actor = HdMan, Item = String, Error = String>> {
     let session = match hd_man.get_session_mut(&session_id) {
         Ok(a) => a,
         Err(e) => return Box::new(fut::err(e.to_string())),
@@ -298,10 +298,10 @@ fn run_command(
         Command::Exec {
             executable,
             args,
-            options,
+            working_dir,
         } => {
-            if options != Default::default() {
-                warn!("ExecOptions unimplemented in hdman");
+            if working_dir != None {
+                warn!("working_dir unimplemented in hdman");
             }
             let executable = session.get_session_exec_path(&executable);
             let session_id = session_id.clone();


### PR DESCRIPTION
It's easier to add it as an extra field in `Command::Exec`, but then using `session.update(...)` from gu-client gets a little more tedious (you need to manually provide the options for each command). An alternative is to add a method to the deployment API, but this will be tricky if we want to run several commands with different working directories (which may actually be the case for gumpi), so I have second thoughts about adding more global state.