### PR TITLE
Allow adding caps to Docker containers

### DIFF
--- a/gu-model/src/dockerman.rs
+++ b/gu-model/src/dockerman.rs
@@ -11,6 +11,9 @@ pub struct CreateOptions {
     pub net: Option<NetDef>,
     #[serde(default)] // default is false
     pub autostart: bool,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub cap_add: Vec<String>,
 }
 
 impl CreateOptions {

--- a/gu-provider/src/dockerman.rs
+++ b/gu-provider/src/dockerman.rs
@@ -423,7 +423,9 @@ impl Handler<CreateSession<CreateOptions>> for DockerMan {
                 workspace
                     .create_dirs()
                     .expect("Creating session dirs failed");
-                let host_config = async_docker::models::HostConfig::new().with_binds(binds);
+                let host_config = async_docker::models::HostConfig::new()
+                    .with_binds(binds)
+                    .with_cap_add(msg.options.cap_add.clone());
 
                 let host_config = match msg.options.net {
                     Some(NetDef::Host {}) => host_config.with_network_mode("host".to_string()),


### PR DESCRIPTION
I don't like the `.clone()` in here, because we're not using `cap_add` later on, but I don't see any clean way to avoid it. (`msg` is moved into the final closure)