### PR TITLE
 Support setting container shm_size 

### DIFF
--- a/gu-model/src/dockerman.rs
+++ b/gu-model/src/dockerman.rs
@@ -11,6 +11,9 @@ pub struct CreateOptions {
     pub net: Option<NetDef>,
     #[serde(default)] // default is false
     pub autostart: bool,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub cap_add: Vec<String>,
 }
 
 impl CreateOptions {

--- a/gu-model/src/dockerman.rs
+++ b/gu-model/src/dockerman.rs
@@ -14,6 +14,9 @@ pub struct CreateOptions {
     #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub cap_add: Vec<String>,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub shm_size: Option<usize>,
 }
 
 impl CreateOptions {

--- a/gu-provider/src/dockerman.rs
+++ b/gu-provider/src/dockerman.rs
@@ -431,6 +431,10 @@ impl Handler<CreateSession<CreateOptions>> for DockerMan {
                     Some(NetDef::Host {}) => host_config.with_network_mode("host".to_string()),
                     _ => host_config,
                 };
+                let host_config = match msg.options.shm_size {
+                    Some(size) => host_config.with_shm_size(size as i32), // FIXME usize
+                    None => host_config
+                };
 
                 let opts = Self::container_config(url.clone(), host_config);
                 info!("config: {:?}", &opts);

--- a/gu-provider/src/dockerman.rs
+++ b/gu-provider/src/dockerman.rs
@@ -423,7 +423,9 @@ impl Handler<CreateSession<CreateOptions>> for DockerMan {
                 workspace
                     .create_dirs()
                     .expect("Creating session dirs failed");
-                let host_config = async_docker::models::HostConfig::new().with_binds(binds);
+                let host_config = async_docker::models::HostConfig::new()
+                    .with_binds(binds)
+                    .with_cap_add(msg.options.cap_add.clone());
 
                 let host_config = match msg.options.net {
                     Some(NetDef::Host {}) => host_config.with_network_mode("host".to_string()),


### PR DESCRIPTION
This PR bases on #253. 
This PR is useless until `async-docker` types for shmsize are fixed.